### PR TITLE
fix(cardgenerator): restore core image generation after ImageModel migration

### DIFF
--- a/cardgenerator/services/card_generation_service.py
+++ b/cardgenerator/services/card_generation_service.py
@@ -181,7 +181,7 @@ class CardGenerationService:
             # Create GenerationEngine request
             ge_request = GEImageGenerationRequest(
                 prompt=sd_prompt,
-                model=ImageModel.IMAGEN4_FAST,  # Maps to fal-ai/imagen4/preview/fast
+                model=ImageModel.NANO_BANANA_PRO,  # fal-ai/nano-banana-pro (~3s; replaces removed imagen4-fast)
                 num_images=num_images,
                 size=ImageSize.SQUARE,  # 1024x1024
             )
@@ -251,7 +251,7 @@ class CardGenerationService:
             # Create GenerationEngine request with image-to-image parameters
             ge_request = GEImageGenerationRequest(
                 prompt=enhanced_prompt,
-                model=ImageModel.FAL_FLUX_LORA_I2I,  # Image-to-image using flux-lora
+                model=ImageModel.FLUX_LORA_I2I,  # fal-ai/flux-lora/image-to-image
                 num_images=num_images,
                 size=ImageSize.PORTRAIT,  # 768x1024 for card format
                 image_url=template_url,


### PR DESCRIPTION
## Summary
- Fixes production 500 on `POST /api/cardgenerator/generate-core-images` caused by stale `ImageModel` enum references left behind after the GenerationEngine model registry cleanup.
- Step 2 (core images): `IMAGEN4_FAST` → `NANO_BANANA_PRO` (`fal-ai/nano-banana-pro`, fast ~3s replacement for removed imagen4-fast).
- Step 3 (border/card images): `FAL_FLUX_LORA_I2I` → `FLUX_LORA_I2I` (`fal-ai/flux-lora/image-to-image`).

## Root cause
Production returned `{"detail":"Failed to generate images: IMAGEN4_FAST"}`. That string is Python 3.11+ `AttributeError: IMAGEN4_FAST` — the enum member no longer exists on deployed GenerationEngine, so the failure happens before any Fal API call.

StatBlockGenerator and `/api/images/*` were migrated to the new model map in `shared/image_models.py`; CardGenerator was not.

## Deploy notes
| Item | Detail |
|------|--------|
| **Repo** | `Drakosfire/DungeonMindServer` only (no LandingPage / nginx / env changes) |
| **Files changed** | `cardgenerator/services/card_generation_service.py` (2 lines) |
| **Fix commit** | `81f35d56655bfe98bfd9fd2ae676e8b0b731f44d` |
| **Pre-fix baseline** | `c0a5b28ae851064ef98f0d5791638935763a9c68` (main @ deploy time) |
| **Service to restart** | `api-server` container (`docker-compose`, port 7860) |
| **Migrations / env** | None |

After merge: update the `DungeonMindServer` submodule pointer in the monorepo (if applicable), pull on the server, rebuild/restart `api-server`.

---

## Rollback plan

### When to rollback
Rollback if **new** failures appear after deploy that are worse than the pre-fix baseline:

| Signal | Action |
|--------|--------|
| Core images 500/502 with Fal or upload errors (not `IMAGEN4_FAST`) | Investigate logs first; rollback if sustained >5 min |
| Step 3 border generation fails with `FLUX_LORA_I2I` / Fal errors | Rollback if step 2 worked but step 3 regressed for all users |
| `api-server` healthcheck failing, other routes down | Rollback immediately |
| Latency/cost unacceptable on `nano-banana-pro` | Prefer model swap forward-fix; rollback only if no quick fix |

**Do not rollback** merely because CardGenerator was broken before — pre-fix prod already returned 500 on core images. Rollback restores that broken state.

### Rollback options (fastest first)

#### Option A — Git revert + redeploy (preferred)
On the server or locally, in `DungeonMindServer`:

```bash
git fetch origin
git checkout main
git pull origin main
git revert -m 1 <merge-commit-sha>   # or: git reset --hard c0a5b28ae851064ef98f0d5791638935763a9c68
```

From monorepo root on the server (`/var/www/DungeonMind`):

```bash
cd /var/www/DungeonMind
# Ensure DungeonMindServer submodule points at reverted SHA, then:
sudo docker-compose build api-server
sudo docker-compose up -d api-server
```

Verify:

```bash
curl -s -o /dev/null -w "%{http_code}\n" http://localhost:7860/health
curl -s -X POST https://www.dungeonmind.net/api/cardgenerator/generate-core-images \
  -F "sdPrompt=rollback smoke test" -F "numImages=1"
# Expect 500 with {"detail":"Failed to generate images: IMAGEN4_FAST"} — confirms rollback to pre-fix code
```

#### Option B — Monorepo directory backup (full stack)
If deploy script created a timestamped backup (`/var/www/DungeonMind_backup_*`):

```bash
LATEST=$(ls -td /var/www/DungeonMind_backup_* | head -1)
sudo docker-compose -f /var/www/DungeonMind/docker-compose.yml down
sudo rm -rf /var/www/DungeonMind
sudo cp -r "$LATEST" /var/www/DungeonMind
cd /var/www/DungeonMind && sudo docker-compose up -d
```

Use when revert is unclear or other services were deployed in the same push.

#### Option C — Surgical hot-patch (emergency only)
Restore the two model lines in `card_generation_service.py` to pre-fix values and restart `api-server` without a full rsync. **Not recommended** — drifts from git; follow with Option A ASAP.

### Rollback verification checklist
- [ ] `GET http://localhost:7860/health` → 200
- [ ] StatBlock / PCG / RulesLawyer smoke routes still respond
- [ ] CardGenerator item text generation still works (`generate-item-dict`)
- [ ] CardGenerator core images fail with `IMAGEN4_FAST` (expected pre-fix behavior)
- [ ] No elevated error rate in `api-server` logs after restart

### Rollback time estimate
~5–10 minutes (rebuild + restart `api-server`; no DB or nginx work).

### Post-rollback forward path
If rolled back due to Fal/model issues, next fix should:
1. Keep enum alignment with `shared/image_models.py` / GenerationEngine
2. Try `FLUX_2_PRO` for step 2 if `NANO_BANANA_PRO` is the failure mode
3. Add a seam test that calls `generate_core_images` against live `ImageModel` registry in CI

---

## Test plan
- [ ] Deploy to staging/prod
- [ ] Record pre-deploy baseline: `curl` returns 500 / `IMAGEN4_FAST` (for rollback comparison)
- [ ] `curl -X POST https://www.dungeonmind.net/api/cardgenerator/generate-core-images -F "sdPrompt=test fantasy boots" -F "numImages=1"` returns 200 with `images` array (not 500)
- [ ] CardGenerator UI: generate item text → proceed to core image step → images generate successfully
- [ ] CardGenerator UI: step 3 border generation completes (validates `FLUX_LORA_I2I` path)
