### PR TITLE
Audit StatBlockGenerator command-board contract

### DIFF
--- a/Docs/Design/AUDIT-statblockgenerator-command-board-contract.md
+++ b/Docs/Design/AUDIT-statblockgenerator-command-board-contract.md
@@ -1,0 +1,342 @@
+# AUDIT: StatBlockGenerator producer contract for DungeonBuddy command-board integration
+
+## Purpose
+
+This audit captures the current StatBlockGenerator producer surface and the contract gaps that matter before DungeonBuddy treats it as a command-board dependency. It is intentionally documentation + fixtures + gap analysis only: no API rewrite, no DungeonBuddy client, no corpus promotion, and no generator workflow UI changes are included in this PR.
+
+## Executive summary
+
+DungeonBuddy can call the existing StatBlockGenerator API today, but only for description-first generation through the current app-facing endpoint. The current response is useful for the existing generator workflow, but it is not a stable draft envelope for external consumers that need provenance, markdown, parsed combat defaults, lifecycle/review state, source references, terrain pressure, and accept-to-combat semantics.
+
+Recommended next step: add a versioned draft contract beside the current router, for example `POST /api/statblockgenerator/v2/generate-draft`, and wrap the existing `StatBlockDetails` generation core with adapter request/response models.
+
+## Current producer surface
+
+### Existing router prefix and endpoints
+
+The StatBlockGenerator FastAPI router is mounted under `APIRouter(prefix="/api/statblockgenerator", tags=["statblockgenerator"])`. Current endpoints include:
+
+| Method | Path | Current role | Command-board relevance |
+| --- | --- | --- | --- |
+| `GET` | `/api/statblockgenerator/health` | Service health. There are currently two route definitions for `/health` in the router, returning different payload shapes. | Useful, but should be normalized for an external contract. |
+| `POST` | `/api/statblockgenerator/generate-statblock` | Description-first statblock generation. Anonymous access is allowed. | Useful generation core, but request/response shape is not enough for DungeonBuddy. |
+| `POST` | `/api/statblockgenerator/validate-statblock` | Validates a `StatBlockDetails` payload with basic or strict validation. | Useful review primitive, but not a review lifecycle envelope. |
+| `POST` | `/api/statblockgenerator/calculate-cr` | Calculates simplified CR analysis from a `StatBlockDetails` payload. | Useful for warnings/defaults, but insufficient alone. |
+| `POST` | `/api/statblockgenerator/upload-image` | Uploads one image for authenticated users. | Not required for command-board draft generation. |
+| `POST` | `/api/statblockgenerator/upload-images` | Uploads many images for authenticated users. | Not required for command-board draft generation. |
+| `POST` | `/api/statblockgenerator/create-project` | Creates a persisted StatBlock project. | Separate from live-use combat drafts. |
+| `GET` | `/api/statblockgenerator/list-projects` | Lists user projects. | Separate from live-use combat drafts. |
+| `GET` | `/api/statblockgenerator/list-all-images` | Lists generated/uploaded images. | Not required for command-board draft generation. |
+| `GET` | `/api/statblockgenerator/project/{project_id}` | Loads a saved project. | Potential source for revision, not the first contract. |
+| `DELETE` | `/api/statblockgenerator/project/{project_id}/image/{image_id}` | Removes a project image. | Out of scope. |
+| `DELETE` | `/api/statblockgenerator/delete-image` | Removes an image. | Out of scope. |
+| `DELETE` | `/api/statblockgenerator/project/{project_id}` | Deletes a project. | Out of scope. |
+| `POST` | `/api/statblockgenerator/save-project` | Saves a project and normalizes IDs in nested list objects. | Corpus/project storage, not live accept-to-combat. |
+| `POST` | `/api/statblockgenerator/save-session` | Persists generator session state. | UI/session persistence, not a producer draft contract. |
+| `GET` | `/api/statblockgenerator/load-session/{session_id}` | Loads generator session state. | UI/session persistence, not a producer draft contract. |
+
+### Existing generation request shape
+
+`POST /api/statblockgenerator/generate-statblock` accepts `CreatureGenerationRequest`:
+
+```json
+{
+  "description": "Natural language creature description",
+  "includeSpellcasting": false,
+  "includeLegendaryActions": false,
+  "includeLairActions": false,
+  "challenge_rating_target": "optional CR target"
+}
+```
+
+The model also accepts snake_case aliases for the boolean fields. The important producer-contract point is that `description` is required and primary; source statblocks, encounter state, terrain pressure, provenance, and review intent are not first-class request fields.
+
+### Existing generation response shape
+
+The router wraps successful generation responses as:
+
+```json
+{
+  "success": true,
+  "data": {
+    "statblock": { "...": "StatBlockDetails serialized with camelCase aliases" },
+    "generation_info": {
+      "prompt_version": "...",
+      "model_used": "gpt-4o-2024-08-06",
+      "generation_time": "ISO timestamp",
+      "structured_outputs": true
+    }
+  },
+  "timestamp": "ISO timestamp",
+  "generation_time_seconds": 0.0
+}
+```
+
+This is an app endpoint response rather than a stable producer draft envelope. It does not name draft lifecycle state, source references, markdown, combat defaults, consumer warnings, or accept-to-combat guidance.
+
+### Existing request/response models
+
+Current useful models:
+
+- `StatBlockDetails`: complete D&D 5e creature statblock with camelCase aliases, combat fields, actions, spellcasting, legendary actions, lair actions, descriptive text, image prompt, project integration metadata, and CR validation.
+- `CreatureGenerationRequest`: description-first generation request with spellcasting, legendary, lair, and target CR options.
+- `StatBlockValidationRequest`: validation wrapper around `StatBlockDetails` plus `strict_validation`.
+- `ProjectCreateRequest`, `SessionSaveRequest`, and generator state/project models: valuable for the existing app workflow, but not a command-board producer contract.
+
+### Existing tests
+
+The existing statblock tests already cover useful primitives:
+
+- Prompt construction for basic generation, spellcasting/legendary options, validation prompts, and CR prompts.
+- Pydantic validation and schema generation for `StatBlockDetails` and related nested models.
+- Ability modifier calculation and CR value validation.
+- Generator initialization with and without OpenAI configuration.
+- Graceful failure when OpenAI is unavailable.
+- Successful structured-output generation through a mocked OpenAI call.
+- OpenAI refusal handling.
+- Basic CR calculation and proficiency bonus calculation.
+- Integration-style generation/validation workflow with mocked output.
+- Project save normalization and pages API coverage in adjacent test files.
+
+### Existing validation and CR limits
+
+Current validation is a helpful start but not the DungeonBuddy legality/review envelope:
+
+- Pydantic validates field types, basic numeric ranges, enum values, and CR string/fraction formats.
+- `validate_statblock` performs basic checks for ability ranges, expected proficiency bonus, hit-points-vs-hit-dice consistency, passive Perception, and a simplified calculated CR.
+- `calculate_challenge_rating` uses a simplified HP/AC/offense heuristic and can include AI analysis when configured.
+- Strict validation can call the LLM, but the result is not currently normalized into typed legality findings, severity levels, or an explicit review status.
+
+## DungeonBuddy consumer needs
+
+DungeonBuddy command-board integration needs StatBlockGenerator to behave like a producer of live combat drafts, not only as a generator app backend.
+
+### Generate from source statblock
+
+DungeonBuddy should be able to send a source statblock or partial statblock, source references, and a desired transformation. Example use cases:
+
+- Create a tripod variant from an existing construct statblock.
+- Reskin a creature while preserving AC/HP/action economy.
+- Generate a battlefield-ready enemy from a lore snippet plus existing creature defaults.
+
+### Revise existing statblock
+
+DungeonBuddy should be able to submit a draft or existing statblock with revision instructions:
+
+- Make this creature weaker for a depleted party.
+- Reduce action complexity for a fast-running encounter.
+- Keep identity and tactics while changing CR band.
+
+### Generate quick reinforcement from combat context
+
+The command board may need a quick reinforcement during an active encounter. The request should support:
+
+- Party level/size and active condition summary.
+- Round number, current threat pressure, and encounter objective.
+- Desired arrival vector and tactical role.
+- Constraints such as "dies in one or two hits" or "controller, not striker".
+
+### Include terrain pressure
+
+Terrain should be a first-class context input, not prose hidden inside `description`. DungeonBuddy needs to communicate pressure such as:
+
+- Choke points, elevation, water, carts, doors, hazards, difficult terrain, light level, cover, and escape routes.
+- Terrain-driven desired actions, reactions, or movement constraints.
+- Warnings when generated abilities ignore the terrain premise.
+
+### Return markdown, parsed combat defaults, warnings, provenance, and review status
+
+A command-board response should be directly usable by the DM without frontend-only interpretation. It should return:
+
+- `markdown`: stable rendered statblock text for display/copy/paste.
+- `statblock`: full `StatBlockDetails` JSON for structured consumers.
+- `combat_defaults`: initiative bonus, passive Perception, AC, HP, speed summary, primary attacks, save DCs, damage expectations, condition immunities, senses, and suggested tactics.
+- `warnings`: typed warnings with severity, field references, and remediation notes.
+- `provenance`: generation mode, model, prompt/schema version, source references, requested changes, and timestamps.
+- `review`: lifecycle state such as `live_draft`, `reviewed`, or `corpus_candidate`.
+
+### Support accept-to-combat without corpus write
+
+DungeonBuddy should be able to accept a generated draft into the active combat tracker without forcing a StatBlockGenerator project save or corpus promotion. Durable corpus/project storage can be added later as a separate workflow.
+
+## Contract gaps
+
+1. **Current request is description-first, not context-bundle-first.** The current required field is `description`; combat context, source statblocks, source references, terrain, target role, and revision instructions have no typed home.
+2. **Current response is `success` / `data` / `timestamp`, not a stable draft envelope.** The response does not provide a named draft ID, lifecycle state, or consumer-safe shape.
+3. **No explicit provenance/sourceRefs.** The only provenance-like fields are prompt version, model name, generation time, and structured-output flag.
+4. **No generated markdown output contract.** Markdown is not returned as an API field, so each frontend/client would need to render independently.
+5. **No parsed combat defaults contract separate from full statblock JSON.** Consumers must derive initiative, attack summaries, save DCs, tactics, and encounter-ready fields themselves.
+6. **No distinction between live-use draft, reviewed draft, and corpus-promotable artifact.** Generated statblocks and persisted projects/sessions are not modeled as separate lifecycle stages.
+7. **Existing validation exists but is not the legality/review envelope DungeonBuddy needs.** Warnings/errors are plain lists, and strict AI analysis is free text when present.
+8. **Existing endpoints are useful, but not yet a versioned external consumer API.** They are primarily app/workflow endpoints under the StatBlockGenerator router.
+9. **`/health` currently has duplicate route definitions.** Before an external contract relies on health responses, the router should expose one canonical health payload.
+
+## Recommended API contract v0
+
+### Design decision
+
+Document both options, but choose **Option A for the next implementation PR** unless the repository already establishes a stronger convention for service-boundary APIs.
+
+#### Option A: v2 producer API beside current app API (recommended first)
+
+Example endpoints under the existing router:
+
+- `POST /api/statblockgenerator/v2/generate-draft`
+- `POST /api/statblockgenerator/v2/revise-draft`
+- `POST /api/statblockgenerator/v2/parse-draft`
+- `GET /api/statblockgenerator/v2/health`
+
+Why this is recommended first:
+
+- Least disruptive to existing `/api/statblockgenerator/generate-statblock` consumers.
+- Makes clear the new contract belongs to StatBlockGenerator, while separating app endpoints from producer draft endpoints.
+- Allows the implementation to wrap the current generation core and reuse `StatBlockDetails`.
+- Leaves room to alias or rename later if the service boundary hardens.
+
+#### Option B: new generic statblocks API
+
+Example endpoints:
+
+- `POST /api/statblocks/generate`
+- `POST /api/statblocks/revise`
+- `POST /api/statblocks/parse`
+- `GET /api/statblocks/health`
+
+Why this may be cleaner later:
+
+- Presents a consumer-oriented service boundary to DungeonBuddy.
+- Avoids tying the long-term contract name to the generator app implementation.
+- Could eventually include non-generator statblock operations.
+
+Why not choose it in the first implementation PR:
+
+- It is a broader routing/service-boundary decision.
+- It risks implying a larger API migration before the draft contract is proven.
+
+### Proposed v0 request envelope
+
+```json
+{
+  "request_id": "db-cmd-2026-06-08T12:00:00Z-001",
+  "mode": "generate_from_prompt | generate_from_source_statblock | revise_existing | quick_reinforcement | terrain_pressure",
+  "intent": {
+    "summary": "Short DM-facing goal",
+    "target_cr": "2",
+    "target_role": "controller",
+    "tone": "grim swamp horror",
+    "complexity": "low | medium | high"
+  },
+  "prompt": "Optional freeform generation prompt",
+  "source_statblock": { "...": "Optional StatBlockDetails or partial statblock" },
+  "revision_instructions": ["Optional list of requested changes"],
+  "encounter_context": {
+    "party_level": 4,
+    "party_size": 5,
+    "round": 3,
+    "threat_pressure": "medium",
+    "objective": "hold the gate for two more rounds"
+  },
+  "terrain_context": {
+    "summary": "Optional terrain summary",
+    "features": ["cart jam", "mud", "half cover"],
+    "hazards": ["burning oil"],
+    "constraints": ["large creatures cannot pass the gate"]
+  },
+  "source_refs": [
+    {
+      "id": "encounter:mireward-gate",
+      "kind": "encounter",
+      "label": "Mireward Gate encounter note"
+    }
+  ],
+  "output_options": {
+    "include_markdown": true,
+    "include_combat_defaults": true,
+    "include_review_warnings": true,
+    "persist": false
+  }
+}
+```
+
+### Proposed v0 response envelope
+
+```json
+{
+  "success": true,
+  "draft": {
+    "draft_id": "sbg-draft-...",
+    "lifecycle_state": "live_draft",
+    "review_status": "needs_dm_review",
+    "statblock": { "...": "StatBlockDetails serialized with aliases" },
+    "markdown": "Rendered statblock markdown",
+    "combat_defaults": {
+      "name": "Cart-Jam Harrier",
+      "armor_class": 13,
+      "hit_points": 22,
+      "initiative_bonus": 2,
+      "passive_perception": 11,
+      "speed_summary": "30 ft.",
+      "primary_actions": ["Hooked Spear", "Shove Cart"],
+      "save_dcs": [],
+      "suggested_tactics": ["Block the lane", "Use carts as half cover"]
+    },
+    "warnings": [
+      {
+        "severity": "review",
+        "code": "terrain_assumption",
+        "message": "Generated shove action assumes unsecured carts.",
+        "field": "actions[1]"
+      }
+    ],
+    "provenance": {
+      "mode": "terrain_pressure",
+      "source_refs": ["encounter:mireward-gate"],
+      "prompt_version": "...",
+      "model_used": "...",
+      "generated_at": "ISO timestamp"
+    }
+  },
+  "timestamp": "ISO timestamp"
+}
+```
+
+## Fixture pack
+
+Fixtures live under `Docs/Design/fixtures/statblockgenerator-command-board-contract/` and model the desired v2 request envelope rather than the current `generate-statblock` shape.
+
+| Fixture | Workflow covered |
+| --- | --- |
+| `generate_from_prompt.basic.json` | Basic prompt-driven draft generation. |
+| `generate_from_source_statblock.tripod_variant.json` | Variant generation from a source statblock and source reference. |
+| `revise_existing.latch_harrow_weaker.json` | Revision of an existing statblock to reduce difficulty. |
+| `quick_reinforcement.mireward_gate.json` | Active-combat reinforcement generation from encounter context. |
+| `terrain_pressure.cart_jam_controller.json` | Terrain-informed controller generation. |
+
+## Implementation recommendation
+
+For PR A1.1:
+
+1. Do not replace `POST /api/statblockgenerator/generate-statblock`.
+2. Add v2 producer-facing routes under the existing router first.
+3. Add request/response adapter models instead of contorting the current app endpoint.
+4. Reuse `StatBlockDetails` as the full structured statblock payload.
+5. Add explicit markdown rendering/export as a contract field.
+6. Add explicit `combat_defaults` extraction separate from the full statblock JSON.
+7. Add typed warnings and review lifecycle state.
+8. Keep `persist: false` as the default for command-board drafts so accept-to-combat does not write to the corpus/project store.
+9. Consider consolidating the duplicate `/health` routes before or during v2 health implementation.
+
+## Not in PR 1
+
+- Do not build the DungeonBuddy client yet.
+- Do not add corpus promotion yet.
+- Do not revise the full generator workflow UI.
+- Do not remove or rewrite `/api/statblockgenerator/generate-statblock`.
+
+## Acceptance checklist answered
+
+- **Can DungeonBuddy call the existing API today?** Yes, but only for description-first generation through `POST /api/statblockgenerator/generate-statblock`.
+- **What shape does the current generator return?** `success`, `data`, `timestamp`, and `generation_time_seconds`; `data` includes `statblock` and `generation_info`.
+- **What is missing for command-board consumption?** Context references, provenance, markdown, parsed combat defaults, review warnings, lifecycle state, terrain context, and accept-to-combat semantics.
+- **What endpoint shape should the next PR implement?** A versioned draft-generation endpoint wrapping the existing core, preferably `POST /api/statblockgenerator/v2/generate-draft` first.
+- **What fixtures prove the desired use cases?** The fixture pack contains five JSON request envelopes mapped directly to DungeonBuddy workflows.

--- a/Docs/Design/fixtures/statblockgenerator-command-board-contract/generate_from_prompt.basic.json
+++ b/Docs/Design/fixtures/statblockgenerator-command-board-contract/generate_from_prompt.basic.json
@@ -1,0 +1,40 @@
+{
+  "request_id": "db-cmd-basic-001",
+  "mode": "generate_from_prompt",
+  "intent": {
+    "summary": "Create a low-complexity swamp ambusher for a level 3 party.",
+    "target_cr": "1",
+    "target_role": "skirmisher",
+    "tone": "muddy folk-horror",
+    "complexity": "low"
+  },
+  "prompt": "A reed-cloaked goblin outrider who fights from shallow bog water and retreats when bloodied.",
+  "source_statblock": null,
+  "revision_instructions": [],
+  "encounter_context": {
+    "party_level": 3,
+    "party_size": 4,
+    "round": null,
+    "threat_pressure": "low",
+    "objective": "Introduce the danger of the mire before the main fight."
+  },
+  "terrain_context": {
+    "summary": "Knee-deep marsh with reeds and patches of sucking mud.",
+    "features": ["shallow water", "reeds", "difficult terrain"],
+    "hazards": ["sucking mud"],
+    "constraints": ["No flying movement", "Avoid legendary actions"]
+  },
+  "source_refs": [
+    {
+      "id": "encounter:mire-scouts",
+      "kind": "encounter_note",
+      "label": "Mire scouts opening encounter"
+    }
+  ],
+  "output_options": {
+    "include_markdown": true,
+    "include_combat_defaults": true,
+    "include_review_warnings": true,
+    "persist": false
+  }
+}

--- a/Docs/Design/fixtures/statblockgenerator-command-board-contract/generate_from_source_statblock.tripod_variant.json
+++ b/Docs/Design/fixtures/statblockgenerator-command-board-contract/generate_from_source_statblock.tripod_variant.json
@@ -1,0 +1,70 @@
+{
+  "request_id": "db-cmd-tripod-variant-001",
+  "mode": "generate_from_source_statblock",
+  "intent": {
+    "summary": "Create a tripod construct variant from an existing guard statblock.",
+    "target_cr": "2",
+    "target_role": "brute-controller",
+    "tone": "arcane salvage horror",
+    "complexity": "medium"
+  },
+  "prompt": "Turn the source guard into a three-legged arcane tripod that pins targets and guards a ruined bridge.",
+  "source_statblock": {
+    "name": "Iron Yard Guard",
+    "size": "Medium",
+    "type": "construct",
+    "alignment": "unaligned",
+    "armorClass": 15,
+    "hitPoints": 45,
+    "hitDice": "6d8+18",
+    "speed": { "walk": 25 },
+    "abilities": { "str": 16, "dex": 10, "con": 16, "int": 3, "wis": 10, "cha": 5 },
+    "senses": { "darkvision": 60, "passive_perception": 10 },
+    "languages": "understands its creator's commands but can't speak",
+    "challengeRating": "2",
+    "xp": 450,
+    "proficiencyBonus": 2,
+    "actions": [
+      {
+        "name": "Slam",
+        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) bludgeoning damage.",
+        "attack_bonus": 5,
+        "damage": "2d6+3",
+        "damage_type": "bludgeoning"
+      }
+    ],
+    "description": "A tireless construct guard built for a noble's yard.",
+    "sdPrompt": "A squat iron construct guard in a ruined courtyard"
+  },
+  "revision_instructions": [
+    "Change movement and action flavor to emphasize three-legged stability.",
+    "Add one pinning or brace action that matters on a narrow bridge.",
+    "Keep CR near 2 and avoid spellcasting."
+  ],
+  "encounter_context": {
+    "party_level": 4,
+    "party_size": 5,
+    "round": null,
+    "threat_pressure": "medium",
+    "objective": "Prevent the party from crossing the bridge too quickly."
+  },
+  "terrain_context": {
+    "summary": "A cracked stone bridge over fast black water.",
+    "features": ["narrow bridge", "broken parapet", "drop hazard"],
+    "hazards": ["falling into river"],
+    "constraints": ["Large creatures cannot stand side by side"]
+  },
+  "source_refs": [
+    {
+      "id": "statblock:iron-yard-guard",
+      "kind": "source_statblock",
+      "label": "Iron Yard Guard homebrew draft"
+    }
+  ],
+  "output_options": {
+    "include_markdown": true,
+    "include_combat_defaults": true,
+    "include_review_warnings": true,
+    "persist": false
+  }
+}

--- a/Docs/Design/fixtures/statblockgenerator-command-board-contract/quick_reinforcement.mireward_gate.json
+++ b/Docs/Design/fixtures/statblockgenerator-command-board-contract/quick_reinforcement.mireward_gate.json
@@ -1,0 +1,49 @@
+{
+  "request_id": "db-cmd-mireward-gate-reinforcement-001",
+  "mode": "quick_reinforcement",
+  "intent": {
+    "summary": "Generate a quick reinforcement that buys two rounds at Mireward Gate.",
+    "target_cr": "1/2",
+    "target_role": "blocker",
+    "tone": "muddy desperate militia",
+    "complexity": "low"
+  },
+  "prompt": "A fragile gate warden reinforcement arrives from the fog and tries to slow the heroes without becoming a major boss.",
+  "source_statblock": null,
+  "revision_instructions": [
+    "Must be runnable immediately with no spell list lookup.",
+    "Should die in one or two solid hits.",
+    "Give it one action that changes positioning at the gate."
+  ],
+  "encounter_context": {
+    "party_level": 3,
+    "party_size": 5,
+    "round": 3,
+    "threat_pressure": "medium-high",
+    "objective": "Hold the gate for two more rounds while villagers escape."
+  },
+  "terrain_context": {
+    "summary": "A half-broken wooden gate in rain and mud.",
+    "features": ["gate arch", "mud", "standing water", "torchlight"],
+    "hazards": ["collapsing beam"],
+    "constraints": ["No flight", "No legendary actions", "Action text must fit on command-board card"]
+  },
+  "source_refs": [
+    {
+      "id": "encounter:mireward-gate",
+      "kind": "encounter",
+      "label": "Mireward Gate active encounter"
+    },
+    {
+      "id": "combat:mireward-gate-round-3",
+      "kind": "combat_state",
+      "label": "Round 3 combat snapshot"
+    }
+  ],
+  "output_options": {
+    "include_markdown": true,
+    "include_combat_defaults": true,
+    "include_review_warnings": true,
+    "persist": false
+  }
+}

--- a/Docs/Design/fixtures/statblockgenerator-command-board-contract/revise_existing.latch_harrow_weaker.json
+++ b/Docs/Design/fixtures/statblockgenerator-command-board-contract/revise_existing.latch_harrow_weaker.json
@@ -1,0 +1,78 @@
+{
+  "request_id": "db-cmd-latch-harrow-001",
+  "mode": "revise_existing",
+  "intent": {
+    "summary": "Weaken Latch Harrow for a tired party without changing the horror identity.",
+    "target_cr": "1",
+    "target_role": "lurker",
+    "tone": "claustrophobic cellar horror",
+    "complexity": "low"
+  },
+  "prompt": "Make the existing statblock less lethal while keeping its latch-and-drag theme.",
+  "source_statblock": {
+    "name": "Latch Harrow",
+    "size": "Medium",
+    "type": "undead",
+    "alignment": "chaotic evil",
+    "armorClass": 14,
+    "hitPoints": 52,
+    "hitDice": "8d8+16",
+    "speed": { "walk": 30, "climb": 20 },
+    "abilities": { "str": 15, "dex": 14, "con": 14, "int": 6, "wis": 12, "cha": 8 },
+    "damageResistance": "necrotic",
+    "conditionImmunity": "frightened",
+    "senses": { "darkvision": 60, "passive_perception": 11 },
+    "languages": "understands Common but speaks only in door-creaks",
+    "challengeRating": "3",
+    "xp": 700,
+    "proficiencyBonus": 2,
+    "actions": [
+      {
+        "name": "Hooking Latch",
+        "desc": "Melee Weapon Attack: +4 to hit, reach 10 ft., one target. Hit: 11 (2d8 + 2) piercing damage, and the target is grappled.",
+        "attack_bonus": 4,
+        "damage": "2d8+2",
+        "damage_type": "piercing"
+      }
+    ],
+    "description": "A gaunt undead thing made of old door iron and knotted tendons.",
+    "sdPrompt": "A gaunt undead latch monster in a root cellar"
+  },
+  "revision_instructions": [
+    "Target CR 1 or lower.",
+    "Reduce hit points and damage.",
+    "Keep one memorable control rider, but make escape straightforward.",
+    "Return a warning if the grapple math still feels too punishing."
+  ],
+  "encounter_context": {
+    "party_level": 2,
+    "party_size": 4,
+    "round": 5,
+    "threat_pressure": "high",
+    "objective": "Let the party survive a final scare after spending resources."
+  },
+  "terrain_context": {
+    "summary": "Low cellar with crates, door frames, and one narrow stairwell.",
+    "features": ["low ceiling", "crates", "narrow stairs"],
+    "hazards": [],
+    "constraints": ["Avoid area attacks", "Avoid multiattack"]
+  },
+  "source_refs": [
+    {
+      "id": "statblock:latch-harrow",
+      "kind": "source_statblock",
+      "label": "Latch Harrow original draft"
+    },
+    {
+      "id": "combat:cellar-round-5",
+      "kind": "combat_state",
+      "label": "Cellar fight round 5"
+    }
+  ],
+  "output_options": {
+    "include_markdown": true,
+    "include_combat_defaults": true,
+    "include_review_warnings": true,
+    "persist": false
+  }
+}

--- a/Docs/Design/fixtures/statblockgenerator-command-board-contract/terrain_pressure.cart_jam_controller.json
+++ b/Docs/Design/fixtures/statblockgenerator-command-board-contract/terrain_pressure.cart_jam_controller.json
@@ -1,0 +1,49 @@
+{
+  "request_id": "db-cmd-cart-jam-controller-001",
+  "mode": "terrain_pressure",
+  "intent": {
+    "summary": "Create a controller whose abilities exploit a cart jam without overwhelming the party.",
+    "target_cr": "2",
+    "target_role": "controller",
+    "tone": "street-level chaos",
+    "complexity": "medium"
+  },
+  "prompt": "A wiry bandit sapper uses jammed carts, ropes, and loose cargo to split the battlefield.",
+  "source_statblock": null,
+  "revision_instructions": [
+    "At least one action should move or restrain a target using cart terrain.",
+    "At least one warning should flag if the terrain assumption is required for balance.",
+    "Avoid permanent conditions."
+  ],
+  "encounter_context": {
+    "party_level": 4,
+    "party_size": 4,
+    "round": 1,
+    "threat_pressure": "medium",
+    "objective": "Delay pursuit through the market lane."
+  },
+  "terrain_context": {
+    "summary": "Two overturned carts block a narrow market lane while crates spill into the street.",
+    "features": ["overturned carts", "narrow lane", "loose crates", "half cover"],
+    "hazards": ["spilled oil", "skittish mule"],
+    "constraints": ["Controller should be weaker in open terrain", "No forced movement over 10 feet"]
+  },
+  "source_refs": [
+    {
+      "id": "map:market-lane-cart-jam",
+      "kind": "map_region",
+      "label": "Market lane cart jam region"
+    },
+    {
+      "id": "encounter:market-pursuit",
+      "kind": "encounter",
+      "label": "Market pursuit encounter"
+    }
+  ],
+  "output_options": {
+    "include_markdown": true,
+    "include_combat_defaults": true,
+    "include_review_warnings": true,
+    "persist": false
+  }
+}


### PR DESCRIPTION
### Motivation

- Capture the current StatBlockGenerator producer surface and identify contract gaps that block DungeonBuddy command-board consumption. 
- Propose a minimal, low-risk v0 producer contract (v2 beside the app API) that exposes draft-generation, revision, parse, and health endpoints while reusing `StatBlockDetails`.
- Provide example fixture requests that map directly to DungeonBuddy workflows so the next PR can implement and test the new route adapters.

### Description

- Added an audit document at `Docs/Design/AUDIT-statblockgenerator-command-board-contract.md` that documents existing endpoints, request/response shapes, validation coverage, consumer needs, contract gaps, and a recommended v0 API envelope. 
- Added a fixture pack under `Docs/Design/fixtures/statblockgenerator-command-board-contract/` containing five JSON examples: `generate_from_prompt.basic.json`, `generate_from_source_statblock.tripod_variant.json`, `revise_existing.latch_harrow_weaker.json`, `quick_reinforcement.mireward_gate.json`, and `terrain_pressure.cart_jam_controller.json` that model the proposed v2 request envelope. 
- This PR is documentation + fixtures only and does not change runtime endpoints or generator code; it recommends adding `POST /api/statblockgenerator/v2/*` routes in a follow-up implementation PR.

### Testing

- Validated all fixture JSON files with `python -m json.tool` in a loop (`for f in Docs/Design/fixtures/statblockgenerator-command-board-contract/*.json; do python -m json.tool "$f" >/dev/null || exit 1; done`) and they passed with no parse errors. 
- No unit or integration code changes were made, so no existing test suites were modified or rerun as part of this PR. 
- Changes were committed as `docs: audit statblock command board contract` and are ready for review as the design/fixture baseline for the follow-up implementation PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26338ff7d08320ba1159cc07fa8b0a)