### PR TITLE
Implement StatBlockGenerator v2 draft API (command-board contract)

### DIFF
--- a/routers/statblockgenerator_router.py
+++ b/routers/statblockgenerator_router.py
@@ -34,11 +34,22 @@ import os
 import fal_client
 from openai import OpenAI
 from cloudflare.handle_images import upload_image_to_cloudflare
+from fastapi.responses import JSONResponse
+
+from statblockgenerator.models.command_board_contract_models import (
+    ContractError,
+    StatBlockDraftRequest,
+    StatBlockDraftResponse,
+)
+from statblockgenerator.services.statblock_draft_adapter import (
+    build_draft,
+    build_generation_request,
+)
 
 # NOTE: Image generation now handled by /api/images/generate (image_management_router.py)
 
 # Initialize OpenAI client (still used for text generation)
-openai_client = OpenAI()
+openai_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY")) if os.getenv("OPENAI_API_KEY") else None
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +78,70 @@ async def health_check():
         "openai_configured": bool(os.getenv("OPENAI_API_KEY")),
         "fal_configured": bool(os.getenv("FAL_KEY"))
     }
+
+
+@router.get("/v2/health")
+async def v2_health_check():
+    """Canonical health check for the command-board draft v2 contract."""
+    return {
+        "status": "ok",
+        "service": "statblockgenerator",
+        "contract": "command_board_draft_v2",
+        "version": "0.1.0",
+        "generator_ready": statblock_generator is not None,
+        "openai_configured": bool(os.getenv("OPENAI_API_KEY")),
+        "supports": ["generate-draft"],
+        "timestamp": datetime.now().isoformat(),
+    }
+
+
+@router.post("/v2/generate-draft", response_model=StatBlockDraftResponse)
+async def generate_statblock_draft(request: StatBlockDraftRequest):
+    """Generate a command-board-ready statblock draft without persisting it."""
+    if request.mode in {"generate_from_source_statblock", "revise_existing"}:
+        response = StatBlockDraftResponse(
+            success=False,
+            error=ContractError(
+                code="not_implemented",
+                message=f"Mode '{request.mode}' is accepted by the contract but not implemented in this v2 slice.",
+                details={"mode": request.mode},
+            ),
+        )
+        return JSONResponse(status_code=501, content=response.model_dump(mode="json"))
+
+    try:
+        generation_request = build_generation_request(request)
+        success, result = await statblock_generator.generate_creature(generation_request)
+
+        if not success:
+            response = StatBlockDraftResponse(
+                success=False,
+                error=ContractError(
+                    code="generation_failed",
+                    message=result.get("error", "Generation failed"),
+                    details={k: v for k, v in result.items() if k != "error"},
+                ),
+            )
+            return JSONResponse(status_code=400, content=response.model_dump(mode="json"))
+
+        draft = build_draft(
+            request=request,
+            statblock_data=result.get("statblock", result),
+            generation_info=result.get("generation_info", {}),
+        )
+        return StatBlockDraftResponse(success=True, draft=draft)
+
+    except Exception as exc:
+        logger.error(f"v2 draft generation failed: {str(exc)}")
+        response = StatBlockDraftResponse(
+            success=False,
+            error=ContractError(
+                code="draft_adapter_failed",
+                message="Draft generation failed while adapting generator output.",
+                details={"error": str(exc)},
+            ),
+        )
+        return JSONResponse(status_code=500, content=response.model_dump(mode="json"))
 
 
 @router.post("/generate-statblock")

--- a/statblockgenerator/models/__init__.py
+++ b/statblockgenerator/models/__init__.py
@@ -2,6 +2,19 @@
 Data models for StatBlock Generator
 """
 
+from .command_board_contract_models import (
+    CombatDefaults,
+    ContractError,
+    DraftProvenance,
+    EncounterContext,
+    OutputOptions,
+    ReviewWarning,
+    SourceRef,
+    StatBlockDraft,
+    StatBlockDraftRequest,
+    StatBlockDraftResponse,
+    TerrainContext,
+)
 from .statblock_models import (
     StatBlockDetails,
     AbilityScores,
@@ -29,5 +42,16 @@ __all__ = [
     "CreatureType", 
     "Alignment",
     "StatBlockProject",
-    "StatBlockGeneratorState"
+    "StatBlockGeneratorState",
+    "CombatDefaults",
+    "ContractError",
+    "DraftProvenance",
+    "EncounterContext",
+    "OutputOptions",
+    "ReviewWarning",
+    "SourceRef",
+    "StatBlockDraft",
+    "StatBlockDraftRequest",
+    "StatBlockDraftResponse",
+    "TerrainContext",
 ]

--- a/statblockgenerator/models/command_board_contract_models.py
+++ b/statblockgenerator/models/command_board_contract_models.py
@@ -164,3 +164,13 @@ class StatBlockDraftResponse(BaseModel):
     draft: Optional[StatBlockDraft] = None
     error: Optional[ContractError] = None
     timestamp: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    @model_validator(mode="after")
+    def validate_success_envelope(self) -> "StatBlockDraftResponse":
+        if self.success and self.draft is None:
+            raise ValueError("successful draft responses require draft")
+
+        if not self.success and self.error is None:
+            raise ValueError("failed draft responses require error")
+
+        return self

--- a/statblockgenerator/models/command_board_contract_models.py
+++ b/statblockgenerator/models/command_board_contract_models.py
@@ -1,0 +1,166 @@
+"""Command-board draft contract models for StatBlockGenerator v2."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Literal, Optional, Union
+
+from pydantic import BaseModel, Field, model_validator
+
+from statblockgenerator.models.statblock_models import StatBlockDetails
+
+DraftMode = Literal[
+    "generate_from_prompt",
+    "generate_from_source_statblock",
+    "revise_existing",
+    "quick_reinforcement",
+    "terrain_pressure",
+]
+
+LifecycleState = Literal["live_draft"]
+ReviewStatus = Literal["needs_dm_review", "warnings", "failed"]
+
+
+class DraftIntent(BaseModel):
+    """High-level command-board intent for a statblock draft."""
+
+    summary: str
+    target_cr: Optional[Union[str, float]] = None
+    target_role: Optional[str] = None
+    tone: Optional[str] = None
+    complexity: Optional[str] = None
+
+
+class EncounterContext(BaseModel):
+    """Encounter details that should influence draft generation."""
+
+    party_level: Optional[int] = None
+    party_size: Optional[int] = None
+    round: Optional[int] = None
+    threat_pressure: Optional[str] = None
+    objective: Optional[str] = None
+
+
+class TerrainContext(BaseModel):
+    """Terrain details that should influence draft generation and warnings."""
+
+    summary: Optional[str] = None
+    features: List[str] = Field(default_factory=list)
+    hazards: List[str] = Field(default_factory=list)
+    constraints: List[str] = Field(default_factory=list)
+
+
+class SourceRef(BaseModel):
+    """Stable reference to command-board, map, encounter, or source data."""
+
+    id: str
+    kind: str
+    label: Optional[str] = None
+
+
+class OutputOptions(BaseModel):
+    """Caller-selected response sections and persistence behavior."""
+
+    include_markdown: bool = True
+    include_combat_defaults: bool = True
+    include_review_warnings: bool = True
+    persist: bool = False
+
+
+class StatBlockDraftRequest(BaseModel):
+    """Request envelope for v2 command-board statblock draft generation."""
+
+    request_id: Optional[str] = None
+    mode: DraftMode
+    intent: DraftIntent
+    prompt: Optional[str] = None
+    source_statblock: Optional[Union[StatBlockDetails, Dict[str, Any]]] = None
+    revision_instructions: List[str] = Field(default_factory=list)
+    encounter_context: Optional[EncounterContext] = None
+    terrain_context: Optional[TerrainContext] = None
+    source_refs: List[SourceRef] = Field(default_factory=list)
+    output_options: OutputOptions = Field(default_factory=OutputOptions)
+
+    @model_validator(mode="after")
+    def validate_generation_inputs(self) -> "StatBlockDraftRequest":
+        prompt = (self.prompt or "").strip()
+        source_present = self.source_statblock is not None
+        instructions_present = any(i.strip() for i in self.revision_instructions)
+
+        if self.mode in {"generate_from_prompt", "quick_reinforcement", "terrain_pressure"} and not prompt:
+            raise ValueError(f"prompt is required for mode '{self.mode}'")
+
+        if self.mode in {"generate_from_source_statblock", "revise_existing"}:
+            if not (prompt or source_present or instructions_present):
+                raise ValueError(
+                    f"mode '{self.mode}' requires prompt, source_statblock, or revision_instructions"
+                )
+
+        return self
+
+
+class CombatDefaults(BaseModel):
+    """Deterministic combat defaults derived from the structured statblock."""
+
+    name: str
+    armor_class: int
+    hit_points: int
+    initiative_bonus: Optional[int] = None
+    passive_perception: Optional[int] = None
+    speed_summary: str
+    primary_actions: List[str] = Field(default_factory=list)
+    save_dcs: List[int] = Field(default_factory=list)
+    senses_summary: Optional[str] = None
+    condition_immunities: Optional[str] = None
+    suggested_tactics: List[str] = Field(default_factory=list)
+
+
+class ReviewWarning(BaseModel):
+    """Lightweight warning for DM review."""
+
+    code: str
+    message: str
+    severity: Literal["info", "warning", "error"] = "warning"
+
+
+class DraftProvenance(BaseModel):
+    """Generation provenance for downstream review and traceability."""
+
+    request_id: Optional[str] = None
+    mode: DraftMode
+    source_refs: List[SourceRef] = Field(default_factory=list)
+    generated_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    generator: str = "StatBlockGenerator.generate_creature"
+    adapter_version: str = "0.1.0"
+    persist_requested: bool = False
+    generation_info: Dict[str, Any] = Field(default_factory=dict)
+
+
+class StatBlockDraft(BaseModel):
+    """Stable v2 statblock draft envelope payload."""
+
+    draft_id: str
+    lifecycle_state: LifecycleState = "live_draft"
+    review_status: ReviewStatus = "needs_dm_review"
+    statblock: StatBlockDetails
+    markdown: str
+    combat_defaults: CombatDefaults
+    warnings: List[ReviewWarning] = Field(default_factory=list)
+    provenance: DraftProvenance
+
+
+class ContractError(BaseModel):
+    """Stable error envelope for v2 contract failures."""
+
+    code: str
+    message: str
+    details: Dict[str, Any] = Field(default_factory=dict)
+
+
+class StatBlockDraftResponse(BaseModel):
+    """Top-level response envelope for v2 draft generation."""
+
+    success: bool
+    draft: Optional[StatBlockDraft] = None
+    error: Optional[ContractError] = None
+    timestamp: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())

--- a/statblockgenerator/services/statblock_draft_adapter.py
+++ b/statblockgenerator/services/statblock_draft_adapter.py
@@ -203,7 +203,7 @@ def build_warnings(
             )
         )
 
-    if not markdown.strip():
+    if request.output_options.include_markdown and not markdown.strip():
         warnings.append(
             ReviewWarning(
                 code="missing_markdown",
@@ -235,7 +235,8 @@ def build_draft(
     markdown = render_markdown(statblock) if request.output_options.include_markdown else ""
     combat_defaults = derive_combat_defaults(statblock)
     warnings = build_warnings(request, statblock, markdown, validation_warnings)
-    review_status = "warnings" if warnings else "needs_dm_review"
+    emitted_warnings = warnings if request.output_options.include_review_warnings else []
+    review_status = "warnings" if emitted_warnings else "needs_dm_review"
 
     return StatBlockDraft(
         draft_id=f"draft-{request.request_id or uuid4().hex}",
@@ -244,7 +245,7 @@ def build_draft(
         statblock=statblock,
         markdown=markdown,
         combat_defaults=combat_defaults,
-        warnings=warnings if request.output_options.include_review_warnings else [],
+        warnings=emitted_warnings,
         provenance=DraftProvenance(
             request_id=request.request_id,
             mode=request.mode,

--- a/statblockgenerator/services/statblock_draft_adapter.py
+++ b/statblockgenerator/services/statblock_draft_adapter.py
@@ -1,0 +1,352 @@
+"""Adapter helpers for StatBlockGenerator v2 command-board drafts."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional, Union
+from uuid import uuid4
+
+from statblockgenerator.models.command_board_contract_models import (
+    CombatDefaults,
+    DraftProvenance,
+    ReviewWarning,
+    StatBlockDraft,
+    StatBlockDraftRequest,
+)
+from statblockgenerator.models.statblock_models import CreatureGenerationRequest, StatBlockDetails
+
+DC_PATTERN = re.compile(r"\bDC\s+(\d{1,2})\b", re.IGNORECASE)
+
+
+def build_generation_request(request: StatBlockDraftRequest) -> CreatureGenerationRequest:
+    """Convert a v2 command-board request into the current generator request."""
+
+    description = compose_generation_description(request)
+    return CreatureGenerationRequest(
+        description=description,
+        challenge_rating_target=request.intent.target_cr,
+        include_spells=False,
+        include_legendary=False,
+        include_lair=False,
+    )
+
+
+def compose_generation_description(request: StatBlockDraftRequest) -> str:
+    """Compose a transparent prompt for the existing StatBlockGenerator core."""
+
+    lines = [
+        f"Mode: {request.mode}",
+        f"Intent: {request.intent.summary}",
+    ]
+    if request.intent.target_cr is not None:
+        lines.append(f"Target CR: {request.intent.target_cr}")
+    if request.intent.target_role:
+        lines.append(f"Role: {request.intent.target_role}")
+    if request.intent.tone:
+        lines.append(f"Tone: {request.intent.tone}")
+    if request.intent.complexity:
+        lines.append(f"Complexity: {request.intent.complexity}")
+    if request.prompt:
+        lines.append(f"Prompt: {request.prompt}")
+
+    if request.encounter_context:
+        context = request.encounter_context
+        encounter_bits = []
+        if context.party_level is not None:
+            encounter_bits.append(f"party level {context.party_level}")
+        if context.party_size is not None:
+            encounter_bits.append(f"party size {context.party_size}")
+        if context.round is not None:
+            encounter_bits.append(f"round {context.round}")
+        if context.threat_pressure:
+            encounter_bits.append(f"threat pressure {context.threat_pressure}")
+        if context.objective:
+            encounter_bits.append(f"objective: {context.objective}")
+        if encounter_bits:
+            lines.append("Encounter context: " + "; ".join(encounter_bits))
+
+    if request.terrain_context:
+        terrain = request.terrain_context
+        if terrain.summary:
+            lines.append(f"Terrain context: {terrain.summary}")
+        if terrain.features:
+            lines.append("Terrain features: " + ", ".join(terrain.features))
+        if terrain.hazards:
+            lines.append("Terrain hazards: " + ", ".join(terrain.hazards))
+        if terrain.constraints:
+            lines.append("Terrain constraints: " + "; ".join(terrain.constraints))
+
+    if request.revision_instructions:
+        lines.append("Revision instructions: " + "; ".join(request.revision_instructions))
+
+    if request.source_statblock:
+        source = request.source_statblock
+        if isinstance(source, StatBlockDetails):
+            source_name = source.name
+        else:
+            source_name = str(source.get("name", "provided source statblock"))
+        lines.append(f"Source statblock: {source_name}")
+
+    return "\n".join(lines)
+
+
+def coerce_statblock(statblock_data: Union[StatBlockDetails, Dict[str, Any]]) -> StatBlockDetails:
+    """Coerce generator output into the structured StatBlockDetails model."""
+
+    if isinstance(statblock_data, StatBlockDetails):
+        return statblock_data
+    return StatBlockDetails.model_validate(statblock_data)
+
+
+def render_markdown(statblock: StatBlockDetails) -> str:
+    """Render a conservative markdown statblock for command-board preview."""
+
+    lines = [
+        f"# {statblock.name}",
+        f"*{statblock.size.value} {statblock.type.value}, {statblock.alignment.value}*",
+        "",
+        f"**Armor Class** {statblock.armor_class}",
+        f"**Hit Points** {statblock.hit_points} ({statblock.hit_dice})",
+        f"**Speed** {speed_summary(statblock)}",
+        "",
+        "|STR|DEX|CON|INT|WIS|CHA|",
+        "|---:|---:|---:|---:|---:|---:|",
+        (
+            f"|{statblock.abilities.str} ({format_modifier(statblock.abilities.get_modifier('str'))})"
+            f"|{statblock.abilities.dex} ({format_modifier(statblock.abilities.get_modifier('dex'))})"
+            f"|{statblock.abilities.con} ({format_modifier(statblock.abilities.get_modifier('con'))})"
+            f"|{statblock.abilities.intelligence} ({format_modifier(statblock.abilities.get_modifier('int'))})"
+            f"|{statblock.abilities.wis} ({format_modifier(statblock.abilities.get_modifier('wis'))})"
+            f"|{statblock.abilities.cha} ({format_modifier(statblock.abilities.get_modifier('cha'))})|"
+        ),
+        "",
+    ]
+
+    if statblock.saving_throws:
+        lines.append("**Saving Throws** " + format_bonus_map(statblock.saving_throws))
+    if statblock.skills:
+        lines.append("**Skills** " + format_bonus_map(statblock.skills))
+    if statblock.damage_resistance:
+        lines.append(f"**Damage Resistances** {statblock.damage_resistance}")
+    if statblock.damage_immunity:
+        lines.append(f"**Damage Immunities** {statblock.damage_immunity}")
+    if statblock.condition_immunity:
+        lines.append(f"**Condition Immunities** {statblock.condition_immunity}")
+    if statblock.damage_vulnerability:
+        lines.append(f"**Damage Vulnerabilities** {statblock.damage_vulnerability}")
+
+    lines.extend(
+        [
+            f"**Senses** {senses_summary(statblock) or 'passive Perception ' + str(statblock.senses.passive_perception)}",
+            f"**Languages** {statblock.languages}",
+            f"**Challenge** {statblock.challenge_rating} ({statblock.xp:,} XP)",
+            "",
+        ]
+    )
+
+    append_action_section(lines, "Traits", statblock.special_abilities)
+    append_action_section(lines, "Actions", statblock.actions)
+    append_action_section(lines, "Bonus Actions", statblock.bonus_actions)
+    append_action_section(lines, "Reactions", statblock.reactions)
+
+    if statblock.description:
+        lines.extend(["## Description", statblock.description])
+
+    return "\n".join(lines).strip()
+
+
+def derive_combat_defaults(statblock: StatBlockDetails) -> CombatDefaults:
+    """Derive command-board combat defaults from the statblock only."""
+
+    return CombatDefaults(
+        name=statblock.name,
+        armor_class=statblock.armor_class,
+        hit_points=statblock.hit_points,
+        initiative_bonus=statblock.abilities.get_modifier("dex"),
+        passive_perception=statblock.senses.passive_perception if statblock.senses else None,
+        speed_summary=speed_summary(statblock),
+        primary_actions=[action.name for action in statblock.actions[:4]],
+        save_dcs=extract_save_dcs(statblock),
+        senses_summary=senses_summary(statblock),
+        condition_immunities=statblock.condition_immunity,
+        suggested_tactics=suggest_tactics(statblock),
+    )
+
+
+def build_warnings(
+    request: StatBlockDraftRequest,
+    statblock: StatBlockDetails,
+    markdown: str,
+    validation_warnings: Optional[Iterable[Any]] = None,
+) -> List[ReviewWarning]:
+    """Build lightweight command-board review warnings."""
+
+    warnings: List[ReviewWarning] = []
+
+    if request.intent.target_cr is not None and normalize_cr(request.intent.target_cr) != normalize_cr(statblock.challenge_rating):
+        warnings.append(
+            ReviewWarning(
+                code="cr_mismatch",
+                message=(
+                    f"Requested target CR {request.intent.target_cr}, but generated statblock is "
+                    f"CR {statblock.challenge_rating}."
+                ),
+            )
+        )
+
+    if request.terrain_context and not statblock_mentions_terrain(statblock, request.terrain_context.features):
+        warnings.append(
+            ReviewWarning(
+                code="terrain_assumption",
+                message="Terrain context was provided, but generated statblock text does not reference terrain features.",
+            )
+        )
+
+    if not markdown.strip():
+        warnings.append(
+            ReviewWarning(
+                code="missing_markdown",
+                message="Markdown rendering failed or produced an empty draft.",
+                severity="error",
+            )
+        )
+
+    for warning in validation_warnings or []:
+        warnings.append(
+            ReviewWarning(
+                code="validation_warning",
+                message=str(warning),
+            )
+        )
+
+    return warnings
+
+
+def build_draft(
+    request: StatBlockDraftRequest,
+    statblock_data: Union[StatBlockDetails, Dict[str, Any]],
+    generation_info: Optional[Dict[str, Any]] = None,
+    validation_warnings: Optional[Iterable[Any]] = None,
+) -> StatBlockDraft:
+    """Build the stable v2 draft envelope from generator output."""
+
+    statblock = coerce_statblock(statblock_data)
+    markdown = render_markdown(statblock) if request.output_options.include_markdown else ""
+    combat_defaults = derive_combat_defaults(statblock)
+    warnings = build_warnings(request, statblock, markdown, validation_warnings)
+    review_status = "warnings" if warnings else "needs_dm_review"
+
+    return StatBlockDraft(
+        draft_id=f"draft-{request.request_id or uuid4().hex}",
+        lifecycle_state="live_draft",
+        review_status=review_status,
+        statblock=statblock,
+        markdown=markdown,
+        combat_defaults=combat_defaults,
+        warnings=warnings if request.output_options.include_review_warnings else [],
+        provenance=DraftProvenance(
+            request_id=request.request_id,
+            mode=request.mode,
+            source_refs=request.source_refs,
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            persist_requested=request.output_options.persist,
+            generation_info=generation_info or {},
+        ),
+    )
+
+
+def append_action_section(lines: List[str], title: str, actions: Optional[List[Any]]) -> None:
+    if not actions:
+        return
+    lines.append(f"## {title}")
+    for action in actions:
+        lines.append(f"**{action.name}.** {action.desc}")
+    lines.append("")
+
+
+def speed_summary(statblock: StatBlockDetails) -> str:
+    speeds = statblock.speed
+    parts = []
+    for label in ("walk", "fly", "swim", "climb", "burrow"):
+        value = getattr(speeds, label)
+        if value is None:
+            continue
+        prefix = "" if label == "walk" else f"{label} "
+        parts.append(f"{prefix}{value} ft.")
+    return ", ".join(parts) or "0 ft."
+
+
+def senses_summary(statblock: StatBlockDetails) -> Optional[str]:
+    senses = statblock.senses
+    if not senses:
+        return None
+    parts = []
+    for label in ("darkvision", "blindsight", "tremorsense", "truesight"):
+        value = getattr(senses, label)
+        if value is not None:
+            parts.append(f"{label} {value} ft.")
+    parts.append(f"passive Perception {senses.passive_perception}")
+    return ", ".join(parts)
+
+
+def extract_save_dcs(statblock: StatBlockDetails) -> List[int]:
+    text_blocks = []
+    for action_list in (
+        statblock.special_abilities,
+        statblock.actions,
+        statblock.bonus_actions,
+        statblock.reactions,
+    ):
+        if action_list:
+            text_blocks.extend(action.desc for action in action_list)
+    if statblock.spells:
+        text_blocks.append(f"DC {statblock.spells.save_dc}")
+
+    dcs = {int(match.group(1)) for text in text_blocks for match in DC_PATTERN.finditer(text or "")}
+    return sorted(dcs)
+
+
+def statblock_mentions_terrain(statblock: StatBlockDetails, features: List[str]) -> bool:
+    if not features:
+        return True
+    searchable = " ".join(
+        [
+            statblock.name,
+            statblock.description,
+            *(action.name + " " + action.desc for action in statblock.actions),
+            *(action.name + " " + action.desc for action in statblock.special_abilities or []),
+            *(action.name + " " + action.desc for action in statblock.bonus_actions or []),
+            *(action.name + " " + action.desc for action in statblock.reactions or []),
+        ]
+    ).lower()
+    return any(feature.lower() in searchable for feature in features)
+
+
+def suggest_tactics(statblock: StatBlockDetails) -> List[str]:
+    tactics = []
+    if statblock.actions:
+        tactics.append(f"Open with {statblock.actions[0].name} when the target is in range.")
+    if statblock.bonus_actions:
+        tactics.append(f"Use {statblock.bonus_actions[0].name} as a bonus action when available.")
+    if statblock.reactions:
+        tactics.append(f"Reserve reaction for {statblock.reactions[0].name}.")
+    return tactics[:3]
+
+
+def format_bonus_map(values: Dict[str, int]) -> str:
+    return ", ".join(f"{key} {format_modifier(value)}" for key, value in values.items())
+
+
+def format_modifier(value: int) -> str:
+    return f"+{value}" if value >= 0 else str(value)
+
+
+def normalize_cr(value: Union[str, float, int]) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip()
+    if "/" in text:
+        numerator, denominator = text.split("/", 1)
+        return float(numerator) / float(denominator)
+    return float(text)

--- a/tests/statblockgenerator/test_command_board_contract_models.py
+++ b/tests/statblockgenerator/test_command_board_contract_models.py
@@ -4,12 +4,14 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from statblockgenerator.models.command_board_contract_models import StatBlockDraftRequest
+from statblockgenerator.models.command_board_contract_models import ContractError, StatBlockDraftResponse, StatBlockDraftRequest
 
-FIXTURE_DIR = Path("Docs/Design/fixtures/statblockgenerator-command-board-contract")
+FIXTURE_DIR = Path(__file__).resolve().parents[2] / "Docs/Design/fixtures/statblockgenerator-command-board-contract"
+FIXTURE_PATHS = sorted(FIXTURE_DIR.glob("*.json"))
+assert FIXTURE_PATHS, f"No command-board contract fixtures found in {FIXTURE_DIR}"
 
 
-@pytest.mark.parametrize("fixture_path", sorted(FIXTURE_DIR.glob("*.json")))
+@pytest.mark.parametrize("fixture_path", FIXTURE_PATHS)
 def test_command_board_fixtures_validate(fixture_path):
     payload = json.loads(fixture_path.read_text())
 
@@ -57,3 +59,26 @@ def test_empty_prompt_allowed_when_source_context_is_sufficient():
 
     assert request.mode == "revise_existing"
     assert request.source_statblock is not None
+
+
+def test_success_response_requires_draft():
+    with pytest.raises(ValidationError) as exc_info:
+        StatBlockDraftResponse(success=True)
+
+    assert "successful draft responses require draft" in str(exc_info.value)
+
+
+def test_failure_response_requires_error():
+    with pytest.raises(ValidationError) as exc_info:
+        StatBlockDraftResponse(success=False)
+
+    assert "failed draft responses require error" in str(exc_info.value)
+
+
+def test_failure_response_accepts_error_envelope():
+    response = StatBlockDraftResponse(
+        success=False,
+        error=ContractError(code="generation_failed", message="Generation failed"),
+    )
+
+    assert response.error.code == "generation_failed"

--- a/tests/statblockgenerator/test_command_board_contract_models.py
+++ b/tests/statblockgenerator/test_command_board_contract_models.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from statblockgenerator.models.command_board_contract_models import StatBlockDraftRequest
+
+FIXTURE_DIR = Path("Docs/Design/fixtures/statblockgenerator-command-board-contract")
+
+
+@pytest.mark.parametrize("fixture_path", sorted(FIXTURE_DIR.glob("*.json")))
+def test_command_board_fixtures_validate(fixture_path):
+    payload = json.loads(fixture_path.read_text())
+
+    request = StatBlockDraftRequest.model_validate(payload)
+
+    assert request.request_id == payload["request_id"]
+    assert request.mode == payload["mode"]
+    assert request.output_options.persist is False
+
+
+def test_output_options_persist_defaults_false_when_omitted():
+    payload = json.loads((FIXTURE_DIR / "generate_from_prompt.basic.json").read_text())
+    payload.pop("output_options")
+
+    request = StatBlockDraftRequest.model_validate(payload)
+
+    assert request.output_options.persist is False
+
+
+def test_invalid_mode_fails_clearly():
+    payload = json.loads((FIXTURE_DIR / "generate_from_prompt.basic.json").read_text())
+    payload["mode"] = "invent_a_mode"
+
+    with pytest.raises(ValidationError) as exc_info:
+        StatBlockDraftRequest.model_validate(payload)
+
+    assert "mode" in str(exc_info.value)
+
+
+def test_prompt_required_for_prompt_generation_modes():
+    payload = json.loads((FIXTURE_DIR / "generate_from_prompt.basic.json").read_text())
+    payload["prompt"] = ""
+
+    with pytest.raises(ValidationError) as exc_info:
+        StatBlockDraftRequest.model_validate(payload)
+
+    assert "prompt is required" in str(exc_info.value)
+
+
+def test_empty_prompt_allowed_when_source_context_is_sufficient():
+    payload = json.loads((FIXTURE_DIR / "revise_existing.latch_harrow_weaker.json").read_text())
+    payload["prompt"] = ""
+
+    request = StatBlockDraftRequest.model_validate(payload)
+
+    assert request.mode == "revise_existing"
+    assert request.source_statblock is not None

--- a/tests/statblockgenerator/test_statblock_draft_adapter.py
+++ b/tests/statblockgenerator/test_statblock_draft_adapter.py
@@ -1,0 +1,131 @@
+import json
+from pathlib import Path
+
+from statblockgenerator.models.command_board_contract_models import StatBlockDraftRequest
+from statblockgenerator.models.statblock_models import StatBlockDetails
+from statblockgenerator.services.statblock_draft_adapter import (
+    build_draft,
+    build_generation_request,
+    build_warnings,
+    derive_combat_defaults,
+    render_markdown,
+)
+
+FIXTURE_DIR = Path("Docs/Design/fixtures/statblockgenerator-command-board-contract")
+
+
+def sample_statblock(**overrides):
+    data = {
+        "name": "Bog Knife Outrider",
+        "size": "Small",
+        "type": "humanoid",
+        "alignment": "neutral evil",
+        "armorClass": 14,
+        "hitPoints": 27,
+        "hitDice": "6d6+6",
+        "speed": {"walk": 30, "swim": 20},
+        "abilities": {"str": 8, "dex": 16, "con": 12, "int": 10, "wis": 12, "cha": 8},
+        "skills": {"Stealth": 5, "Perception": 3},
+        "conditionImmunity": "",
+        "senses": {"darkvision": 60, "passive_perception": 13},
+        "languages": "Common, Goblin",
+        "challengeRating": "1",
+        "xp": 200,
+        "proficiencyBonus": 2,
+        "specialAbilities": [
+            {"name": "Reed Camouflage", "desc": "The outrider has advantage on Dexterity (Stealth) checks in reeds."}
+        ],
+        "actions": [
+            {
+                "name": "Bog Knife",
+                "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 piercing damage.",
+                "attack_bonus": 5,
+                "damage": "1d6+3",
+                "damage_type": "piercing",
+            },
+            {
+                "name": "Mud Snare",
+                "desc": "One creature in mud must succeed on a DC 13 Strength saving throw or be restrained until the end of its next turn.",
+            },
+        ],
+        "description": "A reed-cloaked ambusher that fights from shallow water and sucking mud.",
+        "sdPrompt": "A reed cloaked goblin in a swamp",
+    }
+    data.update(overrides)
+    return StatBlockDetails.model_validate(data)
+
+
+def sample_request():
+    payload = json.loads((FIXTURE_DIR / "generate_from_prompt.basic.json").read_text())
+    return StatBlockDraftRequest.model_validate(payload)
+
+
+def test_generation_request_composes_transparent_description():
+    request = sample_request()
+
+    generation_request = build_generation_request(request)
+
+    assert generation_request.challenge_rating_target == "1"
+    assert "Intent: Create a low-complexity swamp ambusher" in generation_request.description
+    assert "Target CR: 1" in generation_request.description
+    assert "Terrain features: shallow water, reeds, difficult terrain" in generation_request.description
+
+
+def test_markdown_contains_core_statblock_sections():
+    markdown = render_markdown(sample_statblock())
+
+    assert "# Bog Knife Outrider" in markdown
+    assert "**Armor Class** 14" in markdown
+    assert "**Hit Points** 27" in markdown
+    assert "**Speed** 30 ft., swim 20 ft." in markdown
+    assert "**Challenge** 1" in markdown
+    assert "## Actions" in markdown
+    assert "**Bog Knife.**" in markdown
+
+
+def test_combat_defaults_are_deterministic_from_statblock():
+    defaults = derive_combat_defaults(sample_statblock())
+
+    assert defaults.name == "Bog Knife Outrider"
+    assert defaults.armor_class == 14
+    assert defaults.hit_points == 27
+    assert defaults.initiative_bonus == 3
+    assert defaults.passive_perception == 13
+    assert defaults.speed_summary == "30 ft., swim 20 ft."
+    assert defaults.primary_actions == ["Bog Knife", "Mud Snare"]
+    assert defaults.save_dcs == [13]
+    assert defaults.senses_summary == "darkvision 60 ft., passive Perception 13"
+
+
+def test_warnings_include_cr_mismatch():
+    statblock = sample_statblock(challengeRating="2")
+
+    warnings = build_warnings(sample_request(), statblock, render_markdown(statblock))
+
+    assert any(warning.code == "cr_mismatch" for warning in warnings)
+
+
+def test_warnings_include_terrain_assumption_when_terrain_is_ignored():
+    statblock = sample_statblock(
+        actions=[{"name": "Knife", "desc": "Melee Weapon Attack: +5 to hit. Hit: 6 piercing damage."}],
+        specialAbilities=[],
+        description="A plain ambusher with no environmental text.",
+    )
+
+    warnings = build_warnings(sample_request(), statblock, render_markdown(statblock))
+
+    assert any(warning.code == "terrain_assumption" for warning in warnings)
+
+
+def test_build_draft_includes_lifecycle_provenance_and_review_status():
+    request = sample_request()
+
+    draft = build_draft(request, sample_statblock().model_dump(by_alias=True), {"model_used": "mock"})
+
+    assert draft.draft_id == "draft-db-cmd-basic-001"
+    assert draft.lifecycle_state == "live_draft"
+    assert draft.markdown
+    assert draft.combat_defaults.name == "Bog Knife Outrider"
+    assert draft.provenance.request_id == request.request_id
+    assert draft.provenance.persist_requested is False
+    assert draft.provenance.generation_info["model_used"] == "mock"

--- a/tests/statblockgenerator/test_statblock_draft_adapter.py
+++ b/tests/statblockgenerator/test_statblock_draft_adapter.py
@@ -11,7 +11,9 @@ from statblockgenerator.services.statblock_draft_adapter import (
     render_markdown,
 )
 
-FIXTURE_DIR = Path("Docs/Design/fixtures/statblockgenerator-command-board-contract")
+FIXTURE_DIR = Path(__file__).resolve().parents[2] / "Docs/Design/fixtures/statblockgenerator-command-board-contract"
+FIXTURE_PATHS = sorted(FIXTURE_DIR.glob("*.json"))
+assert FIXTURE_PATHS, f"No command-board contract fixtures found in {FIXTURE_DIR}"
 
 
 def sample_statblock(**overrides):
@@ -129,3 +131,24 @@ def test_build_draft_includes_lifecycle_provenance_and_review_status():
     assert draft.provenance.request_id == request.request_id
     assert draft.provenance.persist_requested is False
     assert draft.provenance.generation_info["model_used"] == "mock"
+
+
+def test_missing_markdown_warning_respects_output_option():
+    request = sample_request()
+    request.output_options.include_markdown = False
+
+    draft = build_draft(request, sample_statblock().model_dump(by_alias=True))
+
+    assert draft.markdown == ""
+    assert not any(warning.code == "missing_markdown" for warning in draft.warnings)
+
+
+def test_hidden_review_warnings_do_not_set_warning_status():
+    request = sample_request()
+    request.output_options.include_review_warnings = False
+    statblock = sample_statblock(challengeRating="2")
+
+    draft = build_draft(request, statblock.model_dump(by_alias=True))
+
+    assert draft.warnings == []
+    assert draft.review_status == "needs_dm_review"

--- a/tests/statblockgenerator/test_statblockgenerator_v2_routes.py
+++ b/tests/statblockgenerator/test_statblockgenerator_v2_routes.py
@@ -1,0 +1,101 @@
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from routers import statblockgenerator_router
+from statblockgenerator.models.statblock_models import StatBlockDetails
+
+FIXTURE_DIR = Path("Docs/Design/fixtures/statblockgenerator-command-board-contract")
+
+
+def sample_statblock():
+    return StatBlockDetails.model_validate({
+        "name": "Bog Knife Outrider",
+        "size": "Small",
+        "type": "humanoid",
+        "alignment": "neutral evil",
+        "armorClass": 14,
+        "hitPoints": 27,
+        "hitDice": "6d6+6",
+        "speed": {"walk": 30, "swim": 20},
+        "abilities": {"str": 8, "dex": 16, "con": 12, "int": 10, "wis": 12, "cha": 8},
+        "senses": {"darkvision": 60, "passive_perception": 13},
+        "languages": "Common, Goblin",
+        "challengeRating": "1",
+        "xp": 200,
+        "proficiencyBonus": 2,
+        "actions": [
+            {
+                "name": "Bog Knife",
+                "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 piercing damage.",
+                "attack_bonus": 5,
+                "damage": "1d6+3",
+                "damage_type": "piercing",
+            }
+        ],
+        "description": "A reed-cloaked ambusher that fights from shallow water and sucking mud.",
+        "sdPrompt": "A reed cloaked goblin in a swamp",
+    })
+
+
+def client():
+    app = FastAPI()
+    app.include_router(statblockgenerator_router.router)
+    return TestClient(app)
+
+
+def test_v2_health_returns_contract_payload():
+    response = client().get("/api/statblockgenerator/v2/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["service"] == "statblockgenerator"
+    assert data["contract"] == "command_board_draft_v2"
+    assert data["version"] == "0.1.0"
+    assert data["supports"] == ["generate-draft"]
+
+
+def test_generate_draft_accepts_basic_fixture(monkeypatch):
+    payload = json.loads((FIXTURE_DIR / "generate_from_prompt.basic.json").read_text())
+    mock_generate = AsyncMock(
+        return_value=(
+            True,
+            {
+                "statblock": sample_statblock().model_dump(by_alias=True),
+                "generation_info": {"model_used": "mock-model"},
+            },
+        )
+    )
+    monkeypatch.setattr(statblockgenerator_router.statblock_generator, "generate_creature", mock_generate)
+
+    response = client().post("/api/statblockgenerator/v2/generate-draft", json=payload)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["draft"]["lifecycle_state"] == "live_draft"
+    assert data["draft"]["markdown"]
+    assert data["draft"]["combat_defaults"]["name"] == "Bog Knife Outrider"
+    assert "warnings" in data["draft"]
+    assert data["draft"]["provenance"]["request_id"] == "db-cmd-basic-001"
+    assert data["draft"]["provenance"]["persist_requested"] is False
+    mock_generate.assert_awaited_once()
+
+
+def test_generate_draft_failure_returns_stable_error_envelope(monkeypatch):
+    payload = json.loads((FIXTURE_DIR / "generate_from_prompt.basic.json").read_text())
+    mock_generate = AsyncMock(return_value=(False, {"error": "OpenAI client not initialized"}))
+    monkeypatch.setattr(statblockgenerator_router.statblock_generator, "generate_creature", mock_generate)
+
+    response = client().post("/api/statblockgenerator/v2/generate-draft", json=payload)
+
+    assert response.status_code == 400
+    data = response.json()
+    assert data["success"] is False
+    assert data["draft"] is None
+    assert data["error"]["code"] == "generation_failed"
+    assert data["error"]["message"] == "OpenAI client not initialized"

--- a/tests/statblockgenerator/test_statblockgenerator_v2_routes.py
+++ b/tests/statblockgenerator/test_statblockgenerator_v2_routes.py
@@ -8,7 +8,9 @@ from fastapi.testclient import TestClient
 from routers import statblockgenerator_router
 from statblockgenerator.models.statblock_models import StatBlockDetails
 
-FIXTURE_DIR = Path("Docs/Design/fixtures/statblockgenerator-command-board-contract")
+FIXTURE_DIR = Path(__file__).resolve().parents[2] / "Docs/Design/fixtures/statblockgenerator-command-board-contract"
+FIXTURE_PATHS = sorted(FIXTURE_DIR.glob("*.json"))
+assert FIXTURE_PATHS, f"No command-board contract fixtures found in {FIXTURE_DIR}"
 
 
 def sample_statblock():
@@ -99,3 +101,16 @@ def test_generate_draft_failure_returns_stable_error_envelope(monkeypatch):
     assert data["draft"] is None
     assert data["error"]["code"] == "generation_failed"
     assert data["error"]["message"] == "OpenAI client not initialized"
+
+
+def test_generate_draft_returns_501_for_accepted_unimplemented_modes():
+    payload = json.loads((FIXTURE_DIR / "generate_from_source_statblock.tripod_variant.json").read_text())
+
+    response = client().post("/api/statblockgenerator/v2/generate-draft", json=payload)
+
+    assert response.status_code == 501
+    data = response.json()
+    assert data["success"] is False
+    assert data["draft"] is None
+    assert data["error"]["code"] == "not_implemented"
+    assert data["error"]["details"]["mode"] == "generate_from_source_statblock"


### PR DESCRIPTION
### Motivation

- Provide a narrow v2 producer contract so DungeonBuddy can request reviewed live-combat statblock drafts with structured data, markdown, deterministic combat defaults, warnings, provenance, and a clear lifecycle state. 
- Keep the existing app-facing generation API intact while adding a safe, typed adapter layer that reuses the existing generator core rather than changing generator internals. 

### Description

- Added v2 command-board Pydantic models in `statblockgenerator/models/command_board_contract_models.py` including `StatBlockDraftRequest`, `StatBlockDraft`, `CombatDefaults`, `DraftProvenance`, `ReviewWarning`, and a stable `StatBlockDraftResponse`/`ContractError` envelope. 
- Implemented draft adapter helpers in `statblockgenerator/services/statblock_draft_adapter.py` that convert the v2 request to `CreatureGenerationRequest`, render conservative markdown, derive deterministic `combat_defaults`, extract `save_dcs`, build lightweight `warnings`, and assemble the v2 `StatBlockDraft` with provenance and `persist` defaulting to `false`. 
- Exposed a canonical v2 health route and a generate-draft route by adding `GET /api/statblockgenerator/v2/health` and `POST /api/statblockgenerator/v2/generate-draft` to `routers/statblockgenerator_router.py`, returning `501` for accepted-but-not-implemented revise/source modes and mapping generator failures to the stable error envelope. 
- Exported the new contract models from `statblockgenerator/models/__init__.py` and added unit tests for contract model validation, adapter behavior, and route behavior in `tests/statblockgenerator/test_command_board_contract_models.py`, `tests/statblockgenerator/test_statblock_draft_adapter.py`, and `tests/statblockgenerator/test_statblockgenerator_v2_routes.py` (route tests mock `StatBlockGenerator.generate_creature()` so they do not call OpenAI). 

### Testing

- Performed static checks by compiling the new/changed modules with `python -m py_compile ...` which succeeded for the added files. 
- Attempted to run the unit test suite with `python -m pytest tests/statblockgenerator/test_command_board_contract_models.py -v`, `python -m pytest tests/statblockgenerator/test_statblock_draft_adapter.py -v`, and `python -m pytest tests/statblockgenerator/test_statblockgenerator_v2_routes.py -v`, but test execution was blocked by an environment dependency fetch error for the external `GenerationEngine` dependency (network/Git fetch returned a CONNECT tunnel 403), so the pytest runs could not complete in CI here. 
- Tests are written to avoid live OpenAI calls (route tests mock `generate_creature()`); to validate locally, run the pytest commands above in an environment where `generationengine` can be fetched or vendored and dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2639278520832090325abb54c5b930)