### PR TITLE
Lock down StatBlockGenerator v2 internal endpoints

### DIFF
--- a/routers/internal_auth.py
+++ b/routers/internal_auth.py
@@ -1,0 +1,28 @@
+"""Reusable internal service-to-service authentication dependencies."""
+
+import os
+import secrets
+from typing import Annotated
+
+from fastapi import Header, HTTPException
+
+INTERNAL_KEY_HEADER = "X-DungeonBuddy-Internal-Key"
+INTERNAL_KEY_ENV = "DUNGEONBUDDY_INTERNAL_API_KEY"
+
+
+async def require_dungeonbuddy_internal_key(
+    x_dungeonbuddy_internal_key: Annotated[
+        str | None,
+        Header(alias=INTERNAL_KEY_HEADER),
+    ] = None,
+) -> None:
+    """Require the DungeonBuddy internal API key for protected producer routes."""
+    expected_key = os.getenv(INTERNAL_KEY_ENV)
+    if not expected_key:
+        raise HTTPException(status_code=500, detail="Internal API key is not configured")
+
+    if x_dungeonbuddy_internal_key is None:
+        raise HTTPException(status_code=401, detail="Missing internal API key")
+
+    if not secrets.compare_digest(x_dungeonbuddy_internal_key, expected_key):
+        raise HTTPException(status_code=403, detail="Invalid internal API key")

--- a/routers/statblockgenerator_router.py
+++ b/routers/statblockgenerator_router.py
@@ -11,6 +11,7 @@ import time
 
 # Import authentication
 from .auth_router import get_current_user, get_current_user_optional
+from .internal_auth import require_dungeonbuddy_internal_key
 from auth_service import User
 
 # Import StatBlock components
@@ -82,7 +83,7 @@ async def health_check():
     }
 
 
-@router.get("/v2/health")
+@router.get("/v2/health", dependencies=[Depends(require_dungeonbuddy_internal_key)])
 async def v2_health_check():
     """Canonical health check for the command-board draft v2 contract."""
     return {
@@ -97,7 +98,11 @@ async def v2_health_check():
     }
 
 
-@router.post("/v2/generate-draft", response_model=StatBlockDraftResponse)
+@router.post(
+    "/v2/generate-draft",
+    response_model=StatBlockDraftResponse,
+    dependencies=[Depends(require_dungeonbuddy_internal_key)],
+)
 async def generate_statblock_draft(request: StatBlockDraftRequest):
     """Generate a command-board-ready statblock draft without persisting it."""
     if request.mode in {"generate_from_source_statblock", "revise_existing", "render_existing"}:
@@ -146,7 +151,11 @@ async def generate_statblock_draft(request: StatBlockDraftRequest):
         return JSONResponse(status_code=500, content=response.model_dump(mode="json"))
 
 
-@router.post("/v2/render-draft", response_model=StatBlockDraftResponse)
+@router.post(
+    "/v2/render-draft",
+    response_model=StatBlockDraftResponse,
+    dependencies=[Depends(require_dungeonbuddy_internal_key)],
+)
 async def render_statblock_draft(request: StatBlockDraftRenderRequest):
     """Render an existing statblock into the command-board draft envelope."""
     try:

--- a/tests/statblockgenerator/test_statblockgenerator_v2_auth.py
+++ b/tests/statblockgenerator/test_statblockgenerator_v2_auth.py
@@ -1,0 +1,226 @@
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+
+from routers import statblockgenerator_router
+from routers.internal_auth import (
+    INTERNAL_KEY_ENV,
+    INTERNAL_KEY_HEADER,
+    require_dungeonbuddy_internal_key,
+)
+from statblockgenerator.models.statblock_models import StatBlockDetails
+
+FIXTURE_DIR = Path(__file__).resolve().parents[2] / "Docs/Design/fixtures/statblockgenerator-command-board-contract"
+TEST_INTERNAL_KEY = "test-internal-key"
+
+
+def client():
+    app = FastAPI()
+    app.include_router(statblockgenerator_router.router)
+    return TestClient(app)
+
+
+def auth_headers(key: str = TEST_INTERNAL_KEY):
+    return {INTERNAL_KEY_HEADER: key}
+
+
+def generate_payload():
+    return json.loads((FIXTURE_DIR / "generate_from_prompt.basic.json").read_text())
+
+
+def sample_statblock():
+    return StatBlockDetails.model_validate({
+        "name": "Bog Knife Outrider",
+        "size": "Small",
+        "type": "humanoid",
+        "alignment": "neutral evil",
+        "armorClass": 14,
+        "hitPoints": 27,
+        "hitDice": "6d6+6",
+        "speed": {"walk": 30, "swim": 20},
+        "abilities": {"str": 8, "dex": 16, "con": 12, "int": 10, "wis": 12, "cha": 8},
+        "senses": {"darkvision": 60, "passive_perception": 13},
+        "languages": "Common, Goblin",
+        "challengeRating": "1",
+        "xp": 200,
+        "proficiencyBonus": 2,
+        "actions": [
+            {
+                "name": "Bog Knife",
+                "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 piercing damage.",
+                "attack_bonus": 5,
+                "damage": "1d6+3",
+                "damage_type": "piercing",
+            }
+        ],
+        "description": "A reed-cloaked ambusher that fights from shallow water and sucking mud.",
+        "sdPrompt": "A reed cloaked goblin in a swamp",
+    })
+
+
+def render_payload():
+    return {
+        "request_id": "db-cmd-render-auth-001",
+        "statblock": sample_statblock().model_dump(by_alias=True),
+        "source_refs": [
+            {
+                "id": "combatant:bog-knife-outrider",
+                "kind": "combatant",
+                "label": "Bog Knife Outrider",
+            }
+        ],
+        "output_options": {
+            "include_markdown": True,
+            "include_combat_defaults": True,
+            "include_review_warnings": True,
+            "persist": False,
+        },
+    }
+
+
+def test_v2_health_missing_header_denied(monkeypatch):
+    monkeypatch.setenv(INTERNAL_KEY_ENV, TEST_INTERNAL_KEY)
+
+    response = client().get("/api/statblockgenerator/v2/health")
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Missing internal API key"}
+
+
+def test_v2_health_wrong_header_denied(monkeypatch):
+    monkeypatch.setenv(INTERNAL_KEY_ENV, TEST_INTERNAL_KEY)
+
+    response = client().get(
+        "/api/statblockgenerator/v2/health",
+        headers=auth_headers("wrong-key"),
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Invalid internal API key"}
+
+
+def test_v2_health_correct_header_accepted(monkeypatch):
+    monkeypatch.setenv(INTERNAL_KEY_ENV, TEST_INTERNAL_KEY)
+
+    response = client().get("/api/statblockgenerator/v2/health", headers=auth_headers())
+
+    assert response.status_code == 200
+    assert response.json()["contract"] == "command_board_draft_v2"
+
+
+def test_v2_health_missing_server_env_fails_closed(monkeypatch):
+    monkeypatch.delenv(INTERNAL_KEY_ENV, raising=False)
+
+    response = client().get("/api/statblockgenerator/v2/health", headers=auth_headers())
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Internal API key is not configured"}
+
+
+def test_generate_draft_missing_header_does_not_call_generation(monkeypatch):
+    monkeypatch.setenv(INTERNAL_KEY_ENV, TEST_INTERNAL_KEY)
+    mock_generate = AsyncMock()
+    monkeypatch.setattr(statblockgenerator_router.statblock_generator, "generate_creature", mock_generate)
+
+    response = client().post("/api/statblockgenerator/v2/generate-draft", json=generate_payload())
+
+    assert response.status_code == 401
+    mock_generate.assert_not_awaited()
+
+
+def test_generate_draft_wrong_header_does_not_call_generation(monkeypatch):
+    monkeypatch.setenv(INTERNAL_KEY_ENV, TEST_INTERNAL_KEY)
+    mock_generate = AsyncMock()
+    monkeypatch.setattr(statblockgenerator_router.statblock_generator, "generate_creature", mock_generate)
+
+    response = client().post(
+        "/api/statblockgenerator/v2/generate-draft",
+        json=generate_payload(),
+        headers=auth_headers("wrong-key"),
+    )
+
+    assert response.status_code == 403
+    mock_generate.assert_not_awaited()
+
+
+def test_generate_draft_correct_header_reaches_generation(monkeypatch):
+    monkeypatch.setenv(INTERNAL_KEY_ENV, TEST_INTERNAL_KEY)
+    mock_generate = AsyncMock(
+        return_value=(
+            True,
+            {
+                "statblock": sample_statblock().model_dump(by_alias=True),
+                "generation_info": {"model_used": "mock-model"},
+            },
+        )
+    )
+    monkeypatch.setattr(statblockgenerator_router.statblock_generator, "generate_creature", mock_generate)
+
+    response = client().post(
+        "/api/statblockgenerator/v2/generate-draft",
+        json=generate_payload(),
+        headers=auth_headers(),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    mock_generate.assert_awaited_once()
+
+
+def test_render_draft_missing_header_does_not_render(monkeypatch):
+    monkeypatch.setenv(INTERNAL_KEY_ENV, TEST_INTERNAL_KEY)
+    mock_build_draft = Mock()
+    monkeypatch.setattr(statblockgenerator_router, "build_draft", mock_build_draft)
+
+    response = client().post("/api/statblockgenerator/v2/render-draft", json=render_payload())
+
+    assert response.status_code == 401
+    assert "draft" not in response.json()
+    mock_build_draft.assert_not_called()
+
+
+def test_render_draft_wrong_header_does_not_render(monkeypatch):
+    monkeypatch.setenv(INTERNAL_KEY_ENV, TEST_INTERNAL_KEY)
+    mock_build_draft = Mock()
+    monkeypatch.setattr(statblockgenerator_router, "build_draft", mock_build_draft)
+
+    response = client().post(
+        "/api/statblockgenerator/v2/render-draft",
+        json=render_payload(),
+        headers=auth_headers("wrong-key"),
+    )
+
+    assert response.status_code == 403
+    assert "draft" not in response.json()
+    mock_build_draft.assert_not_called()
+
+
+def test_render_draft_correct_header_reaches_rendering(monkeypatch):
+    monkeypatch.setenv(INTERNAL_KEY_ENV, TEST_INTERNAL_KEY)
+
+    response = client().post(
+        "/api/statblockgenerator/v2/render-draft",
+        json=render_payload(),
+        headers=auth_headers(),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    assert response.json()["draft"]["draft_id"] == "draft-db-cmd-render-auth-001"
+
+
+def test_legacy_generate_statblock_route_does_not_require_internal_key():
+    route = next(
+        route
+        for route in statblockgenerator_router.router.routes
+        if isinstance(route, APIRoute)
+        and route.path == "/api/statblockgenerator/generate-statblock"
+        and "POST" in route.methods
+    )
+
+    dependency_calls = {dependency.call for dependency in route.dependant.dependencies}
+    assert require_dungeonbuddy_internal_key not in dependency_calls

--- a/tests/statblockgenerator/test_statblockgenerator_v2_routes.py
+++ b/tests/statblockgenerator/test_statblockgenerator_v2_routes.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from routers import statblockgenerator_router
+from routers.internal_auth import INTERNAL_KEY_ENV, INTERNAL_KEY_HEADER
 from statblockgenerator.models.statblock_models import StatBlockDetails
 
 FIXTURE_DIR = Path(__file__).resolve().parents[2] / "Docs/Design/fixtures/statblockgenerator-command-board-contract"
@@ -49,8 +50,14 @@ def client():
     return TestClient(app)
 
 
-def test_v2_health_returns_contract_payload():
-    response = client().get("/api/statblockgenerator/v2/health")
+def internal_headers():
+    return {INTERNAL_KEY_HEADER: "test-internal-key"}
+
+
+def test_v2_health_returns_contract_payload(monkeypatch):
+    monkeypatch.setenv(INTERNAL_KEY_ENV, "test-internal-key")
+
+    response = client().get("/api/statblockgenerator/v2/health", headers=internal_headers())
 
     assert response.status_code == 200
     data = response.json()
@@ -62,6 +69,7 @@ def test_v2_health_returns_contract_payload():
 
 
 def test_generate_draft_accepts_basic_fixture(monkeypatch):
+    monkeypatch.setenv(INTERNAL_KEY_ENV, "test-internal-key")
     payload = json.loads((FIXTURE_DIR / "generate_from_prompt.basic.json").read_text())
     mock_generate = AsyncMock(
         return_value=(
@@ -74,7 +82,7 @@ def test_generate_draft_accepts_basic_fixture(monkeypatch):
     )
     monkeypatch.setattr(statblockgenerator_router.statblock_generator, "generate_creature", mock_generate)
 
-    response = client().post("/api/statblockgenerator/v2/generate-draft", json=payload)
+    response = client().post("/api/statblockgenerator/v2/generate-draft", json=payload, headers=internal_headers())
 
     assert response.status_code == 200
     data = response.json()
@@ -89,6 +97,7 @@ def test_generate_draft_accepts_basic_fixture(monkeypatch):
 
 
 def test_render_draft_wraps_existing_statblock_without_generation(monkeypatch):
+    monkeypatch.setenv(INTERNAL_KEY_ENV, "test-internal-key")
     mock_generate = AsyncMock()
     monkeypatch.setattr(statblockgenerator_router.statblock_generator, "generate_creature", mock_generate)
     payload = {
@@ -109,7 +118,7 @@ def test_render_draft_wraps_existing_statblock_without_generation(monkeypatch):
         },
     }
 
-    response = client().post("/api/statblockgenerator/v2/render-draft", json=payload)
+    response = client().post("/api/statblockgenerator/v2/render-draft", json=payload, headers=internal_headers())
 
     assert response.status_code == 200
     data = response.json()
@@ -130,11 +139,12 @@ def test_render_draft_wraps_existing_statblock_without_generation(monkeypatch):
 
 
 def test_generate_draft_failure_returns_stable_error_envelope(monkeypatch):
+    monkeypatch.setenv(INTERNAL_KEY_ENV, "test-internal-key")
     payload = json.loads((FIXTURE_DIR / "generate_from_prompt.basic.json").read_text())
     mock_generate = AsyncMock(return_value=(False, {"error": "OpenAI client not initialized"}))
     monkeypatch.setattr(statblockgenerator_router.statblock_generator, "generate_creature", mock_generate)
 
-    response = client().post("/api/statblockgenerator/v2/generate-draft", json=payload)
+    response = client().post("/api/statblockgenerator/v2/generate-draft", json=payload, headers=internal_headers())
 
     assert response.status_code == 400
     data = response.json()
@@ -144,10 +154,11 @@ def test_generate_draft_failure_returns_stable_error_envelope(monkeypatch):
     assert data["error"]["message"] == "OpenAI client not initialized"
 
 
-def test_generate_draft_returns_501_for_accepted_unimplemented_modes():
+def test_generate_draft_returns_501_for_accepted_unimplemented_modes(monkeypatch):
+    monkeypatch.setenv(INTERNAL_KEY_ENV, "test-internal-key")
     payload = json.loads((FIXTURE_DIR / "generate_from_source_statblock.tripod_variant.json").read_text())
 
-    response = client().post("/api/statblockgenerator/v2/generate-draft", json=payload)
+    response = client().post("/api/statblockgenerator/v2/generate-draft", json=payload, headers=internal_headers())
 
     assert response.status_code == 501
     data = response.json()


### PR DESCRIPTION
### Motivation

- The StatBlockGenerator v2 producer endpoints are intended for internal service consumers and must be protected from anonymous internet callers. 
- Add a narrow, shared-secret gate so internal product backends (e.g. DungeonBuddy) can call v2 routes server-to-server without exposing a secret to browsers. 

### Description

- Added a small reusable FastAPI dependency in `routers/internal_auth.py` that reads `DUNGEONBUDDY_INTERNAL_API_KEY` and validates the `X-DungeonBuddy-Internal-Key` header using `secrets.compare_digest`. 
- Applied the dependency to the v2 producer routes only: `GET /api/statblockgenerator/v2/health`, `POST /api/statblockgenerator/v2/generate-draft`, and `POST /api/statblockgenerator/v2/render-draft`, leaving legacy `POST /api/statblockgenerator/generate-statblock` unchanged. 
- Updated `routers/statblockgenerator_router.py` to import and attach `require_dungeonbuddy_internal_key` to those routes as route-level dependencies. 
- Added focused tests `tests/statblockgenerator/test_statblockgenerator_v2_auth.py` and updated `tests/statblockgenerator/test_statblockgenerator_v2_routes.py` to set the env var and send the internal header; tests cover missing/wrong/correct key behavior, missing server config, ensure generation/render logic is not invoked when auth fails, and assert the legacy route has no internal-key dependency. 

### Testing

- Performed static checks and compilation: `python -m py_compile routers/internal_auth.py routers/statblockgenerator_router.py tests/statblockgenerator/test_statblockgenerator_v2_auth.py tests/statblockgenerator/test_statblockgenerator_v2_routes.py` (succeeded). 
- Ran repository diff/checks for accidental changes (succeeded). 
- Attempted to run the focused tests with `python -m pytest tests/statblockgenerator/test_statblockgenerator_v2_auth.py tests/statblockgenerator/test_statblockgenerator_v2_routes.py -v` but the test run was blocked by the environment: `ModuleNotFoundError: No module named 'dotenv'` (missing `python-dotenv`). 
- Attempted a constrained `uv` run to use a different Python, but dependency sync failed while fetching a git-based dependency (`generationengine`) due to network restrictions (CONNECT tunnel 403), preventing full pytest execution in this environment. 

All new tests are included and validated by static checks; they exercise missing/wrong/correct key paths and ensure generation/render functions are not invoked when auth fails, but running them end-to-end requires installing test dependencies (`python-dotenv`) and allowing access to the `generationengine` dependency in CI or a developer environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26ce83153c8320a4b79f0fd733d6d0)